### PR TITLE
"breadcrumbs_setting"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
 gem 'active_hash'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -331,6 +333,7 @@ DEPENDENCIES
   fog-aws
   font-awesome-rails
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   kaminari

--- a/app/assets/stylesheets/users/users.scss
+++ b/app/assets/stylesheets/users/users.scss
@@ -61,7 +61,6 @@ a {
 .mypage-sidebar {
   float: left;
   display: block;
-  margin-top: -18px;
   max-width:320px;
   width:100%;
 

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,0 +1,15 @@
+- case params.values_at :controller, :action
+
+- when ['users', 'index']
+  - breadcrumb :users
+
+- when ['users', 'edit']
+  - breadcrumb :edit
+
+- when ['users', 'show']
+  - breadcrumb :show
+
+- when ['items', 'new']
+  - breadcrumb :items_new
+
+= breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "

--- a/app/views/users/_users-navigation.html.haml
+++ b/app/views/users/_users-navigation.html.haml
@@ -1,7 +1,4 @@
 .navigation
   .navigation__container
     .navigation__container__content
-      = link_to "" do
-        %span メルカリ 
-        %i.fa.fa-angle-right{"aria-hidden" => "true"}
-        %span  マイページ
+      = render "shared/breadcrumbs"

--- a/app/views/users/_users-sidebar.html.haml
+++ b/app/views/users/_users-sidebar.html.haml
@@ -1,6 +1,6 @@
 .mypage-sidebar
   .mypage-sidebar__container
-    = link_to users_path do
+    = link_to  user_path(current_user) do
       #sidebar-active.mypage-sidebar__container__title
         %h2.weight マイページ
         %i.fa.fa-chevron-right{"aria-hidden" => "true"}
@@ -85,7 +85,7 @@
         .mypage-sidebar__container__title
           %h2 メール/パスワード
           %i.fa.fa-chevron-right{"aria-hidden" => "true"}
-      = link_to  do
+      = link_to new_user_path(current_user) do
         .mypage-sidebar__container__title
           %h2 本人情報
           %i.fa.fa-chevron-right{"aria-hidden" => "true"}

--- a/app/views/users/_users-sidebar.html.haml
+++ b/app/views/users/_users-sidebar.html.haml
@@ -1,6 +1,6 @@
 .mypage-sidebar
   .mypage-sidebar__container
-    = link_to  user_path(current_user) do
+    = link_to users_path do
       #sidebar-active.mypage-sidebar__container__title
         %h2.weight マイページ
         %i.fa.fa-chevron-right{"aria-hidden" => "true"}
@@ -85,7 +85,7 @@
         .mypage-sidebar__container__title
           %h2 メール/パスワード
           %i.fa.fa-chevron-right{"aria-hidden" => "true"}
-      = link_to new_user_path(current_user) do
+      = link_to user_path(current_user) do
         .mypage-sidebar__container__title
           %h2 本人情報
           %i.fa.fa-chevron-right{"aria-hidden" => "true"}

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -4,6 +4,5 @@
 .users-edit
   .users-edit__wrap
     = render "users/users-sidebar"
-    = render "users/users-edit-content"
 = render '/items/footer' 
     

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,8 +1,7 @@
-
 = render '/items/header'
 = render "users-navigation"
 .users-edit
   .users-edit__wrap
     = render "users/users-sidebar"
+    = render "users/users-edit-content"
 = render '/items/footer' 
-    

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,12 +1,5 @@
 = render '/items/header'
-.navigation
-  .navigation__container
-    .navigation__container__content
-      = link_to "" do
-        %span メルカリ 
-        %i.fa.fa-angle-right{"aria-hidden" => "true"}
-        %span  マイページ
-      = render "/shared/breadcrumbs"
+= render "users-navigation"
 
 .mypage
   .mypage__main

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -6,6 +6,8 @@
         %span メルカリ 
         %i.fa.fa-angle-right{"aria-hidden" => "true"}
         %span  マイページ
+      = render "/shared/breadcrumbs"
+
 .mypage
   .mypage__main
     = render "users-sidebar"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,4 @@
+= render '/items/header'
 = render "users-navigation"
 
 .mypage

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,50 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+crumb :users do
+  link "マイページ", users_path
+  parent :root
+end
+
+crumb :edit do
+  link "プロフィール", edit_user_path(current_user)
+  parent :users
+end
+
+crumb :show do
+  link "本人情報の登録", user_path(current_user)
+  parent :users
+end
+
+crumb :items do
+  link "出品", new_item_path
+  parent :users
+end
+
+
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,28 +23,3 @@ crumb :items do
 end
 
 
-
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#what 
パンクズリストを作成

#why
ユーザーが現在のページはどこか視覚的にわかるようにすることで、
ユーザービリティが上がるようにする

開発者もページ事に、現在のページのコードを書くのではなく
部分テープレートとしてパンクズリストを扱うのが効率化になる