### PR TITLE
Basic認証_production_only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,15 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
 
   private
 
+  def production?
+    Rails.env.production?
+  end
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/config/carrierwave.rb
+++ b/config/carrierwave.rb
@@ -1,0 +1,20 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_directory  = 'mercari-team-g'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari-team-g'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+    region: 'ap-northeast-1'
+  }else
+  config.storage :fog
+  config.enable_processing = false if Rails.env.test?
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,7 @@
 server '3.115.154.119', user: 'ec2-user', roles: %w{app db web}
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.


### PR DESCRIPTION
#what
Basic認証をローカルから外す

#why
本サイトはメルカリのコピーサイトであり、Basic認証機能とは、サイトインするために
入室者を制御するための機能
production上で、メルカリのコピーサイトをユーザーが入室するのは、著作権の問題があるので
一般ユーザーは入室できないように管理するため
よって、Basic認証はproductionのみで良い